### PR TITLE
Patched for Rails v4.x to v5.2

### DIFF
--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -39,13 +39,13 @@ module Mobylette
       # Private: finds the right template on the filesystem,
       #         using fallback if needed
       #
-      def find_templates(name, prefix, partial, details)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
           details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
         end
-        super(name, prefix, partial, details)
+        super(name, prefix, partial, details, outside_app_allowed)
       end
 
       # Helper for building query glob string based on resolver's pattern.

--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -39,13 +39,19 @@ module Mobylette
       # Private: finds the right template on the filesystem,
       #         using fallback if needed
       #
-      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = nil)
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
           details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
         end
-        super(name, prefix, partial, details, outside_app_allowed)
+
+        if outside_app_allowed.nil?
+          # Consider the backward compatibility with older Rails
+          super(name, prefix, partial, details)
+        else
+          super(name, prefix, partial, details, outside_app_allowed)
+        end
       end
 
       # Helper for building query glob string based on resolver's pattern.

--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -64,8 +64,12 @@ module Mobylette
         partial = escape_entry(path.partial? ? "_#{path.name}" : path.name)
         query.gsub!(/\:action/, partial)
 
-        details.each do |ext, variants|
-          query.gsub!(/\:#{ext}/, "{#{variants.compact.uniq.join(',')}}")
+        details.each do |ext, candidates|
+          if ext == :variants && candidates == :any
+            query.gsub!(/:#{ext}/, "*")
+          else
+            query.gsub!(/:#{ext}/, "{#{candidates.compact.uniq.join(',')}}")
+          end
         end
 
         query.gsub!(/\:path/, "#{@paths.compact.uniq.join(',')}")

--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -33,7 +33,7 @@ module Mobylette
       helper_method :is_mobile_view?
       helper_method :request_device?
 
-      before_filter :handle_mobile
+      before_action :handle_mobile
 
       cattr_accessor :mobylette_options
       @@mobylette_options = Hash.new


### PR DESCRIPTION
Patched for Rails v4.x to v5.2

Change detail for rails 5.x

- `before_fileter` deprecated in rails 5.1
     - [Remove deprecated methods related to controller filters · rails/rails@d7be30e](https://github.com/rails/rails/commit/d7be30e8babf5e37a891522869e7b0191b79b757)
- https://github.com/rails/rails/blob/v5.2.3/actionview/lib/action_view/template/resolver.rb#L270-L276